### PR TITLE
Fixes to handle existence of default stream_context context

### DIFF
--- a/libraries/OAuth2_Provider.php
+++ b/libraries/OAuth2_Provider.php
@@ -174,7 +174,8 @@ abstract class OAuth2_Provider {
 						'content' => $postdata
 					)
 				);
-				$context  = stream_context_create($opts);
+				$_default_opts = stream_context_get_params(stream_context_get_default());
+				$context = stream_context_create(array_merge_recursive($_default_opts['options'], $opts));
 				$response = file_get_contents($url, false, $context);
 
 				$return = json_decode($response, true);

--- a/libraries/providers/google.php
+++ b/libraries/providers/google.php
@@ -59,16 +59,15 @@ class OAuth2_Provider_Google extends OAuth2_Provider {
 		));
 		
 		$user = json_decode(file_get_contents($url), true);
-		
 		return array(
 			'uid' => $user['id'],
 			'nickname' => url_title($user['name'], '_', true),
 			'name' => $user['name'],
 			'first_name' => $user['given_name'],
 			'last_name' => $user['family_name'],
-			'email' => null,
+			'email' => $user['email'],
 			'location' => null,
-			'image' => null,
+			'image' => $user['picture'],
 			'description' => null,
 			'urls' => array(),
 		);


### PR DESCRIPTION
In my case, the web server runs can access web data through a proxy. So I have
to define a default proxy setting for file_get_context to use by stream_context_set_deafult
function. So while a file_get_context requires to provide custom context it should
do that by changing the default context.

Also, Google OAuth2 response provides email info, so that should be returned as
user_data.
