### PR TITLE
Fix for the nickname PHP notice if the Facebook user doesn't have a user...

### DIFF
--- a/libraries/Provider/Facebook.php
+++ b/libraries/Provider/Facebook.php
@@ -34,7 +34,7 @@ class OAuth2_Provider_Facebook extends OAuth2_Provider
 		// Create a response from the request
 		return array(
 			'uid' => $user->id,
-			'nickname' => $user->username,
+			'nickname' => isset($user->username) ? $user->username : null,
 			'name' => $user->name,
 			'first_name' => $user->first_name,
 			'last_name' => $user->last_name,


### PR DESCRIPTION
When the user comes back to the controller and they didn't have a facebook username set they would get the following :-

A PHP Error was encountered
Severity: Notice
Message: Undefined property: stdClass::$username
Filename: Provider/Facebook.php
Line Number: 37
