### PR TITLE
Append $params with provider specific attr.

### DIFF
--- a/libraries/Provider.php
+++ b/libraries/Provider.php
@@ -125,6 +125,8 @@ abstract class OAuth2_Provider
 			'approval_prompt'   => 'force' // - google force-recheck
 		);
 		
+		$params = array_merge($params, $this->params);
+		
 		redirect($this->url_authorize().'?'.http_build_query($params));
 	}
 
@@ -141,6 +143,8 @@ abstract class OAuth2_Provider
 			'client_secret' => $this->client_secret,
 			'grant_type' 	=> isset($options['grant_type']) ? $options['grant_type'] : 'authorization_code',
 		);
+		
+		$params = array_merge($params, $this->params);
 
 		switch ($params['grant_type'])
 		{


### PR DESCRIPTION
I noticed the $params var wouldn't get added in the auth and access methods. I added a simple array append to get around it for my custom provider class.
